### PR TITLE
Fix fan tool

### DIFF
--- a/app/controllers/fan_tool.coffee
+++ b/app/controllers/fan_tool.coffee
@@ -43,7 +43,6 @@ class FanTool extends MarkingTool
 
   onFirstClick: (e) ->
     @mark.set
-      version: 2
       source: @mouseOffset e
       angle: 90
     super

--- a/app/models/fan_mark.coffee
+++ b/app/models/fan_mark.coffee
@@ -6,6 +6,7 @@ class FanMark extends Mark
   distance: 0
   angle: 0
   spread: 0
+  version: 2
 
   constructor: ->
     super
@@ -21,6 +22,6 @@ class FanMark extends Mark
   'set spread': (value) -> Math.min 179.99, Math.max 1, value
 
   toJSON: ->
-    {@type, @source, @distance, @angle, @spread}
+    {@type, @source, @distance, @angle, @spread, @version}
 
 module.exports = FanMark


### PR DESCRIPTION
I was drawing the semicircle of the fan using the radius of a circle inscribed in the fan's extended triangle (from the `source` point out to the `distance` point) when I should have been using the side of a _square_ inscribed in _half_ that triangle (Brooke figured out the math here), so the error starts small and gets more severe with larger `spread` angles.
